### PR TITLE
pydantic version -MRO comment added

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "A Python package for working with battery ontologies."
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-    "pydantic>=2.0,<3",
+    "pydantic>=2.0,<3", # pydantic 1.9 causes Method Resolution Order (MRO) errors; must use 2.x
     "jinja2>=3.1,<4",
     "rdflib>=6.0,<7",
     "requests>=2.31,<3",


### PR DESCRIPTION
MRo issues stems from using pydantic 1.9, pydantic 2 works fine
pydantic2 merges the conflicting config classes whereas the pydantic1 tries to make a nested config 
